### PR TITLE
Compton has been removed from logos packages.

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -1,4 +1,3 @@
-compton -b
 feh --bg-tile ~/.i3/wallpaper.jpg
 mpd &
 exec i3


### PR DESCRIPTION
See:
https://github.com/install-logos/logos/commit/90cd1ffc263e2a1f1bf44f21a17a5f09c291409f
Don't know that software, you can still ask to re-add it on the package file :)
